### PR TITLE
Add support for persistent hidden services

### DIFF
--- a/examples/Relay.lhs
+++ b/examples/Relay.lhs
@@ -60,7 +60,7 @@ control service, let's set up a new onion service which redirects incoming
 connections to the 'newConnection' function.
 
 >     withinSession (publicPort, privatePort) controlSock = do
->       onion <- Tor.accept controlSock publicPort (newConnection privatePort)
+>       onion <- Tor.accept controlSock publicPort Nothing (newConnection privatePort)
 >       putStrLn ("hidden service descriptor: " ++ show onion)
 
 If we would leave this function at this point, our connection with the Tor

--- a/src/Network/Anonymous/Tor.hs
+++ b/src/Network/Anonymous/Tor.hs
@@ -18,9 +18,7 @@ module Network.Anonymous.Tor (
   -- * Server side
   -- $tor-server
   , P.mapOnion
-  , P.mapPersistentOnion
   , accept
-  , acceptPersistent
 
   -- * Probing Tor configuration information
   , P.Availability (..)
@@ -161,13 +159,17 @@ withSession port callback =
                                             _ <- P.authenticate sock
                                             callback sock)
 
--- | Generalization of 'accept' and 'acceptPersistent'
-genericAccept :: MonadIO m
-       => m a                       -- ^ MonadIO action doing the onion mapping
-       -> Integer                   -- ^ Port to listen at
-       -> (Network.Socket -> IO ()) -- ^ Callback function called for each incoming connection
-       -> m a                       -- ^ Returns the result of the mapping function
-genericAccept mapOnion port callback = do
+-- | Convenience function that creates a new hidden service and starts accepting
+--   connections for it. Note that this creates a new local server at the same
+--   port as the public port, so ensure that the port is not yet in use.
+accept :: MonadIO m
+       => Network.Socket                      -- ^ Connection with Tor control server
+       -> Integer                             -- ^ Port to listen at
+       -> Maybe BS.ByteString                 -- ^ Optional private key to use to set up the hidden service
+       -> (Network.Socket -> IO ())           -- ^ Callback function called for each incoming connection
+       -> m B32.Base32String -- ^ Returns the hidden service descriptor created without
+                                              --   the '.onion' part
+accept sock port pkey callback = do
   -- First create local service
   _ <- liftIO $ forkIO $
        NST.listen "*" (show port) (\(lsock, _) ->
@@ -177,29 +179,4 @@ genericAccept mapOnion port callback = do
                                                                return ()))
 
   -- Do the onion mapping after that
-  mapOnion
-
--- | Convenience function that creates a new hidden service and starts accepting
---   connections for it. Note that this creates a new local server at the same
---   port as the public port, so ensure that the port is not yet in use.
-accept :: MonadIO m
-       => Network.Socket            -- ^ Connection with Tor control server
-       -> Integer                   -- ^ Port to listen at
-       -> (Network.Socket -> IO ()) -- ^ Callback function called for each incoming connection
-       -> m B32.Base32String        -- ^ Returns the hidden service descriptor created
-                                    --   without the '.onion' part.
-accept sock port = genericAccept (P.mapOnion sock port port) port
-
--- | Convenience function that creates a hidden service from an existing
---   private key in base64 and starts accepting connections for it. Note that
---   this creates a new local server at the same port as the public port, so
---   ensure that the port is not yet in use.
-acceptPersistent :: MonadIO m
-       => Network.Socket            -- ^ Connection with Tor control server
-       -> Integer                   -- ^ Port to listen at
-       -> (Network.Socket -> IO ()) -- ^ Callback function called for each incoming connection
-       -> BS.ByteString             -- ^ Private key in Base64
-       -> m B32.Base32String        -- ^ Returns the hidden service descriptor created
-                                    --   without the '.onion' part.
-acceptPersistent sock port callback pkey =
-  genericAccept (P.mapPersistentOnion sock port port pkey) port callback
+  P.mapOnion sock port port False pkey

--- a/src/Network/Anonymous/Tor/Protocol.hs
+++ b/src/Network/Anonymous/Tor/Protocol.hs
@@ -16,7 +16,8 @@ module Network.Anonymous.Tor.Protocol ( Availability (..)
                                       , connect'
                                       , protocolInfo
                                       , authenticate
-                                      , mapOnion ) where
+                                      , mapOnion
+                                      , mapPersistentOnion ) where
 
 import           Control.Concurrent.MVar
 
@@ -243,5 +244,19 @@ mapOnion :: MonadIO m
          -> m B32.Base32String -- ^ The address/service id of the Onion without the .onion aprt
 mapOnion s rport lport = do
   reply <- sendCommand s (BS8.concat ["ADD_ONION NEW:BEST Port=", BS8.pack (show rport), ",127.0.0.1:", BS8.pack(show lport), "\n"])
+
+  return . B32.b32String' . fromJust . Ast.tokenValue . head . Ast.lineMessage . fromJust $ Ast.line (BS8.pack "ServiceID") reply
+
+-- | Creates a hidden service from an existing private key in base64 and maps
+--   a public port to a local port. Useful for bridging a local service (e.g. a
+--   webserver or irc daemon) as a Tor hidden service.
+mapPersistentOnion :: MonadIO m
+         => Network.Socket     -- ^ Connection with tor Control port
+         -> Integer            -- ^ Remote point of hidden service to listen at
+         -> Integer            -- ^ Local port to map onion service to
+         -> BS.ByteString      -- ^ Private key in Base64
+         -> m B32.Base32String -- ^ The address/service id of the Onion without the .onion aprt
+mapPersistentOnion s rport lport pkey = do
+  reply <- sendCommand s (BS8.pack "ADD_ONION RSA1024:" `BS.append` pkey `BS.append` BS8.concat [" Port=", BS8.pack (show rport), ",127.0.0.1:", BS8.pack(show lport), "\n"])
 
   return . B32.b32String' . fromJust . Ast.tokenValue . head . Ast.lineMessage . fromJust $ Ast.line (BS8.pack "ServiceID") reply

--- a/test/Network/Anonymous/Tor/ProtocolSpec.hs
+++ b/test/Network/Anonymous/Tor/ProtocolSpec.hs
@@ -110,7 +110,7 @@ spec = do
 
         _ <- connect $ \controlSock -> do
           P.authenticate controlSock
-          addr <- P.mapOnion controlSock 80 8080
+          addr <- P.mapOnion controlSock 80 8080 False Nothing
 
           putStrLn ("got onion address: " ++ show addr)
           putStrLn ("waiting 1 minute..")

--- a/test/Network/Anonymous/TorSpec.hs
+++ b/test/Network/Anonymous/TorSpec.hs
@@ -35,7 +35,7 @@ spec = do
 
       where
         withinSession clientDone serverDone sock = do
-          onion <- Tor.accept sock 4321 (serverWorker serverDone)
+          onion <- Tor.accept sock 4321 Nothing (serverWorker serverDone)
 
           putStrLn ("Got Tor hidden server: " ++ show onion)
           putStrLn ("waiting 30 seconds..")


### PR DESCRIPTION
I need them for a project I'm working on and thought other people might need it as well.

I haven't found any nice ways to generate that private key, though. One possible way is, to first call`ADD_ONION` on some random local port, taking the key generated by it and destroying the hidden service using `DEL_ONION`.
Should I push the code for that as well or is it too much of a hack?
