### PR TITLE
Add support for authentication method NULL

### DIFF
--- a/src/Network/Anonymous/Tor/Protocol.hs
+++ b/src/Network/Anonymous/Tor/Protocol.hs
@@ -147,8 +147,13 @@ socksPort :: MonadIO m
           -> m Integer
 socksPort s = do
   reply <- sendCommand s (BS8.pack "GETCONF SOCKSPORT\n")
-
-  return . fst . fromJust . BS8.readInteger . fromJust . Ast.tokenValue . head . Ast.lineMessage . fromJust $ Ast.line (BS8.pack "SocksPort") reply
+  let line = fromJust $ Ast.line (BS8.pack "SocksPort") reply
+  let token = fromJust . Ast.tokenValue . head $ Ast.lineMessage line
+  return . fst . fromJust . BS8.readInteger $ removeAddress token
+  -- Removes the optional address: part from [address:]port strings
+  where removeAddress str = if ':' `BS8.elem` str
+                            then BS8.tail $ BS8.dropWhile (/= ':') str
+                            else str
 
 -- | Connect through a remote using the Tor SOCKS proxy. The remote might me a
 --   a normal host/ip or a hidden service address. When you provide a FQDN to

--- a/src/Network/Anonymous/Tor/Protocol/Types.hs
+++ b/src/Network/Anonymous/Tor/Protocol/Types.hs
@@ -4,7 +4,7 @@ module Network.Anonymous.Tor.Protocol.Types where
 
 -- | Authentication types supported by the Tor service
 data AuthMethod =
-  Cookie | SafeCookie | HashedPassword
+  Cookie | SafeCookie | HashedPassword | Null
 
   deriving (Eq)
 
@@ -12,12 +12,14 @@ instance Read AuthMethod where
   readsPrec _ "COOKIE" = [(Cookie, "")]
   readsPrec _ "SAFECOOKIE" = [(SafeCookie, "")]
   readsPrec _ "HASHEDPASSWORD" = [(HashedPassword, "")]
+  readsPrec _ "NULL" = [(Null, "")]
   readsPrec _ s = error ("Not a valid AuthMethod: " ++ s)
 
 instance Show AuthMethod where
   show Cookie = "COOKIE"
   show SafeCookie = "SAFECOOKIE"
   show HashedPassword = "HASHEDPASSWORD"
+  show Null = "NULL"
 
 -- | Information about our protocol (and version)
 data ProtocolInfo = ProtocolInfo {

--- a/test/Network/Anonymous/Tor/ProtocolSpec.hs
+++ b/test/Network/Anonymous/Tor/ProtocolSpec.hs
@@ -8,6 +8,8 @@ import           Control.Concurrent.MVar
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 
+import           Data.List                            (intersect)
+
 import qualified Network.Simple.TCP                   as NS (accept, connect,
                                                              listen, send)
 import qualified Network.Socket                       as NS (Socket)
@@ -57,9 +59,10 @@ spec = do
       port `shouldSatisfy` (> 1024)
 
   describe "when detecting protocol info" $ do
-    it "should allow cookie authentication" $ do
+    it "should allow cookie or null authentication" $ do
       info <- connect P.protocolInfo
-      (PT.authMethods info) `shouldSatisfy` (elem PT.Cookie)
+      (PT.authMethods info) `shouldSatisfy`
+        (not . null . intersect [PT.Cookie, PT.Null])
 
   describe "when authenticating with Tor" $ do
     it "should succeed" $ do


### PR DESCRIPTION
Without this commit, the only supported authentication method is via a cookie file.  This is fairly annoying (even though you could argue it’s more secure), especially if you’re just testing.

This PR adds support for the NULL authentication method which will be used as a fallback in case cookie file authentication is not enabled.

We could additionally fall back to NULL whenever COOKIE fails, which would be more complicated but kinda feels more complete.  I decided against it since I think cookie authentication is more secure (However I didn’t research whether it is), so no authentication should really only be used for testing.
