### PR TITLE
check size of cookie file

### DIFF
--- a/src/Network/Anonymous/Tor/Protocol.hs
+++ b/src/Network/Anonymous/Tor/Protocol.hs
@@ -233,7 +233,11 @@ authenticate s = do
 
     readCookie :: Maybe FilePath -> IO HS.HexString
     readCookie Nothing     = E.torError (E.mkTorError . E.protocolErrorType $ "No cookie path specified.")
-    readCookie (Just file) = return . HS.fromBytes =<< BS.readFile file
+    readCookie (Just file) = do
+    	b <- BS.readFile file
+	if BS.length b == 32
+		then return (HS.fromBytes b)
+		else E.torError (E.mkTorError . E.protocolErrorType $ "Invalid cookie file specified.")
 
     errorF :: Ast.Line -> Maybe E.TorErrorType
     errorF (Ast.Line 250 _) = Nothing


### PR DESCRIPTION
The documentation notes that the cookie file is always 32 bytes, and
requires that any other size file not be used as an auth cookie.

This is a very basic guard against tor asking for any file as a cookie.
It's not sufficient to really secure the cookie auth method. This is a
stopgap measure until SECURECOOKIE can be implemented.
