### PR TITLE
Fallback fetch for SOCKS port using non-torrc GETCONF

### DIFF
--- a/network-anonymous-tor.cabal
+++ b/network-anonymous-tor.cabal
@@ -1,6 +1,6 @@
 name: network-anonymous-tor
 category: Network
-version: 0.10.0
+version: 0.10.1
 license: MIT
 license-file: LICENSE
 copyright: (c) 2014 Leon Mergen


### PR DESCRIPTION
- Since tor 0.3.0.3-alpha, the SOCKS port could potentially be set and
  not written to `torrc`. If this happens, `getconf SocksPort` will not
  return the SOCKS port, but `getconf __SocksPort` will.
- `socksPort` was thus modified to fallback on `getconf __SocksPort`
  returns Nothing

fix #7 