### PR TITLE
Add support for hidden services v3

### DIFF
--- a/src/Network/Anonymous/Tor.hs
+++ b/src/Network/Anonymous/Tor.hs
@@ -179,4 +179,4 @@ accept sock port pkey callback = do
                                                                return ()))
 
   -- Do the onion mapping after that
-  P.mapOnion sock port port False pkey
+  P.mapOnionV3 sock port port False pkey


### PR DESCRIPTION
Tor now has support for hidden services v3 for quite a while. This library lacks support for it.

Note: This code exits because I needed a rather quick solution. I would vote for a cleaner solution that is a little more effort. This PR, although being functional, does not feel like the proper solution to the problem.

This PR adds basic support for hidden services v3. To aquire this it applies the following changes:
* It changes the `mapOnion` function to create a hidden services v2 key if no secret key is given.
* Additionally to the `mapOnion` function it adds another `mapOnionV3` function that implements the same behaviour for hidden services v3. Also tests are duplicated for this function.
* The `accept` function now uses `mapOnionV3`.

The latter one is kind of a breaking change as accept is not able to cunsume hidden services v2 keys any longer. But duplicating `accept` felt somewhat wrong to me.

Mid term I would vote for rewriting this library a bit and utilizing its own types for the keys. This would deduplicate `mapOnion` and `mapOnionV3` again and also would empower `accept` to work with hidden services v2 again.